### PR TITLE
replace deprecated nerd-fonts icon

### DIFF
--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -182,7 +182,7 @@ fi
   readonly show_host=" #[fg=$thm_text]#H #[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]󰒋"
 
   local show_date_time
-  readonly show_date_time="$field_separator#[fg=$thm_foam]$date_time #[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]"
+  readonly show_date_time="$field_separator#[fg=$thm_foam]$date_time #[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]󰃰"
 
   local show_directory
   readonly show_directory=" #[fg=$thm_subtle] #[fg=$thm_rose]#{b:pane_current_path} #{?client_prefix,$spacer#[fg=${thm_love}]$right_separator#[fg=$thm_bg] $field_separator"


### PR DESCRIPTION
with nerd-fonts v3.0.0 some material design icons were removed [see Changelog](https://www.nerdfonts.com/releases). The new icon is an alternative.
You can check for deprecated icons with the [nerdfix](https://github.com/loichyan/nerdfix) tool.

Best regards