### PR TITLE
Fix a bug in rose-pine.tmux

### DIFF
--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -237,7 +237,7 @@ fi
 
   set status-right "$right_column1$right_column2"
 
-  set -g status-interval 1
+  set status-interval 1
 
   setw window-status-format "$window_status_format"
 


### PR DESCRIPTION
Extraneous "-g" causes rose-pine.tmux to crash for my at the moment, meaning the window title changes are not applied. Fixed here.