### PR TITLE
Fix set -g and spacing on window names

### DIFF
--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -237,7 +237,7 @@ fi
 
   set status-right "$right_column1$right_column2"
 
-  set status-interval 1
+  set -g status-interval 1
 
   setw window-status-format "$window_status_format"
 


### PR DESCRIPTION
Reverts rose-pine/tmux#5

For some reason, this "bug" on @gkanwar 's setup breaks the window name updating.
But this is the result on my setup:
![image](https://github.com/rose-pine/tmux/assets/121260905/dd79628d-efb2-4d69-bd35-f11733ec346d)
It somehow breaks the window name in another way, and instead of the application that is running, it shows the current working directory for that window.

I need to look into this more in-depth. For now it gets a rollback. Sorry for the troubles