### PR TITLE
Remove message style "align"

### DIFF
--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -116,8 +116,8 @@ main() {
     set status-right-length "200"
 
     # Theoretically messages (need to figure out color placement) 
-    set message-style "fg=$thm_muted,bg=$thm_base,align=centre"
-    set message-command-style "fg=$thm_base,bg=$thm_gold,align=centre"
+    set message-style "fg=$thm_muted,bg=$thm_base"
+    set message-command-style "fg=$thm_base,bg=$thm_gold"
 
     # Pane styling
     set pane-border-style "fg=$thm_hl_high"


### PR DESCRIPTION
The plugin wasn't rendering at all for me on tmux 2.7 (which is the latest version used in CentOS 8 Stream, which I use at work), so this small change meant the plugin would render the status line properly. Given my understanding of how this is rendering, I'm not able to see any major change for this, but please correct me if I'm wrong. 