### PR TITLE
Add disabled bg color option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,11 @@ set -g @rose_pine_date_time '' # It accepts the date UNIX command format (man da
 set -g @rose_pine_user 'on' # Turn on the username component in the statusbar
 set -g @rose_pine_bar_bg_disable 'on' 
 # If set to 'on', disables background color, for transparent terminal emulators
-set -g @rose_pine_bar_bg_disabled_color_option '0' # If @rose_pine_bar_bg_disable is set to 'on', uses this value to set bg color
+set -g @rose_pine_bar_bg_disabled_color_option '0'
+# If @rose_pine_bar_bg_disable is set to 'on', uses the provided value to set the background color
+# It can be any of the on tmux (named colors, 256-color set, `default` or hex colors)
+# See more on http://man.openbsd.org/OpenBSD-current/man1/tmux.1#STYLES
+
 set -g @rose_pine_only_windows 'on' # Leaves only the window module, for max focus and space
 set -g @rose_pine_disable_active_window_menu 'on' # Disables the menu that shows the active window on the left
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ set -g @rose_pine_date_time '' # It accepts the date UNIX command format (man da
 set -g @rose_pine_user 'on' # Turn on the username component in the statusbar
 set -g @rose_pine_bar_bg_disable 'on' 
 # If set to 'on', disables background color, for transparent terminal emulators
+set -g @rose_pine_bar_bg_transparent_option '0' # If @rose_pine_bar_bg_disable is set to 'on', uses this value to set bg color
 set -g @rose_pine_only_windows 'on' # Leaves only the window module, for max focus and space
 set -g @rose_pine_disable_active_window_menu 'on' # Disables the menu that shows the active window on the left
 

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ set -g @rose_pine_date_time '' # It accepts the date UNIX command format (man da
 set -g @rose_pine_user 'on' # Turn on the username component in the statusbar
 set -g @rose_pine_bar_bg_disable 'on' 
 # If set to 'on', disables background color, for transparent terminal emulators
-set -g @rose_pine_bar_bg_transparent_option '0' # If @rose_pine_bar_bg_disable is set to 'on', uses this value to set bg color
+set -g @rose_pine_bar_bg_disabled_color_option '0' # If @rose_pine_bar_bg_disable is set to 'on', uses this value to set bg color
 set -g @rose_pine_only_windows 'on' # Leaves only the window module, for max focus and space
 set -g @rose_pine_disable_active_window_menu 'on' # Disables the menu that shows the active window on the left
 

--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -180,7 +180,7 @@ main() {
 
     # Transparent option for status bar
     local bar_bg_disabled_color_option
-    bar_bg_disabled_color_option="$(get_tmux_option "@rose_pine_bar_bg_transparent_option" "0")"
+    bar_bg_disabled_color_option="$(get_tmux_option "@rose_pine_bar_bg_disabled_color_option" "0")"
     readonly bar_bg_disabled_color_option
 
     # Shows hostname of the computer the tmux session is run on

--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -177,7 +177,12 @@ main() {
     local bar_bg_disable
     bar_bg_disable="$(get_tmux_option "@rose_pine_bar_bg_disable" "")"
     readonly bar_bg_disable
-    #
+
+    # Transparent option for status bar
+    local bar_bg_disabled_color_option
+    bar_bg_disabled_color_option="$(get_tmux_option "@rose_pine_bar_bg_transparent_option" "0")"
+    readonly bar_bg_disabled_color_option
+
     # Shows hostname of the computer the tmux session is run on
     local only_windows
     only_windows="$(get_tmux_option "@rose_pine_only_windows" "")"
@@ -305,13 +310,13 @@ main() {
     # It sets the base colors for active / inactive, no matter the window appearence switcher choice
     # TEST: This needs to be tested further
     if [[ "$bar_bg_disable" == "on" ]]; then 
-        set status-style "fg=$thm_pine,bg=0"
-        show_window_in_window_status="#[fg=$thm_iris,bg=0]#I#[fg=$thm_iris,bg=0]$left_separator#[fg=$thm_iris,bg=0]#W"
-        show_window_in_window_status_current="#[fg=$thm_gold,bg=0]#I#[fg=$thm_gold,bg=0]$left_separator#[fg=$thm_gold,bg=0]#W"
-        show_directory_in_window_status="#[fg=$thm_iris,bg=0]#I#[fg=$thm_iris,bg=0]$left_separator#[fg=$thm_iris,bg=0]#{b:pane_current_path}"
-        show_directory_in_window_status_current="#[fg=$thm_gold,bg=0]#I#[fg=$thm_gold,bg=0]$left_separator#[fg=$thm_gold,bg=0]#{b:pane_current_path}"
-        set window-status-style "fg=$thm_iris,bg=0"
-        set window-status-current-style "fg=$thm_gold,bg=0"
+        set status-style "fg=$thm_pine,bg=$bar_bg_disabled_color_option"
+        show_window_in_window_status="#[fg=$thm_iris,bg=$bar_bg_disabled_color_option]#I#[fg=$thm_iris,bg=$bar_bg_disabled_color_option]$left_separator#[fg=$thm_iris,bg=$bar_bg_disabled_color_option]#W"
+        show_window_in_window_status_current="#[fg=$thm_gold,bg=$bar_bg_disabled_color_option]#I#[fg=$thm_gold,bg=$bar_bg_disabled_color_option]$left_separator#[fg=$thm_gold,bg=$bar_bg_disabled_color_option]#W"
+        show_directory_in_window_status="#[fg=$thm_iris,bg=$bar_bg_disabled_color_option]#I#[fg=$thm_iris,bg=$bar_bg_disabled_color_option]$left_separator#[fg=$thm_iris,bg=$bar_bg_disabled_color_option]#{b:pane_current_path}"
+        show_directory_in_window_status_current="#[fg=$thm_gold,bg=$bar_bg_disabled_color_option]#I#[fg=$thm_gold,bg=$bar_bg_disabled_color_option]$left_separator#[fg=$thm_gold,bg=$bar_bg_disabled_color_option]#{b:pane_current_path}"
+        set window-status-style "fg=$thm_iris,bg=$bar_bg_disabled_color_option"
+        set window-status-current-style "fg=$thm_gold,bg=$bar_bg_disabled_color_option"
     fi
 
     # Window appearence switcher: 3 options for the user


### PR DESCRIPTION
Add config option to allow users to set the color of disabled background.

On my machine when you set `bg="0"` it wasn't working. But if I use `default`, then it worked.

I'm using iTerm 3.4.20, MacOS Ventura 13.5.2, Apple M1.