### PR TITLE
Turn on @rose_pine_directory option in readme.md suggested config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ For updating the plugin, the key combination is <kbd>Prefix + U</kbd> (which TPM
 set -g @rose_pine_host 'on' # Enables hostname in the status bar
 set -g @rose_pine_date_time '' # It accepts the date UNIX command format (man date for info)
 set -g @rose_pine_user 'on' # Turn on the username component in the statusbar
+set -g @rose_pine_directory 'on' # Turn on the current folder component in the status bar
 set -g @rose_pine_bar_bg_disable 'on' 
 # If set to 'on', disables background color, for transparent terminal emulators
 set -g @rose_pine_bar_bg_disabled_color_option '0'


### PR DESCRIPTION
I noticed the @rose_pine_directory option is on in the screenshots, but is not mentioned anywhere on readme.md.

This PR turns that option on in the "Optional but recommended" step of the installation instructions, next to where the other status bar areas like datetime and hostname are turned on.

This will help people achieve the same end result as the screenshots show!