### PR TITLE
feat: prefix pressed indication to session icon

### DIFF
--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -288,7 +288,7 @@ main() {
     show_window_in_window_status_current="#I#[fg=$thm_gold,bg=""]$left_separator#[fg=$thm_gold,bg=""]#W"
 
     local show_session
-    readonly show_session=" #[fg=$thm_text]$current_session_icon #[fg=$thm_text]#S "
+    readonly show_session=" #[fg=#{?client_prefix,$thm_love,$thm_text}]$current_session_icon #[fg=$thm_text]#S "
 
     local show_user
     readonly show_user="#[fg=$thm_iris]#(whoami)#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$username_icon"


### PR DESCRIPTION
This makes tmux look like this when prefix is pressed
<img width="223" alt="image" src="https://github.com/user-attachments/assets/7476be41-3306-4e77-97eb-a0952d4cfc83">

inspired by catppuccin