### PR TITLE
feat: add @rose_pine_hostname_short option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ For updating the plugin, the key combination is <kbd>Prefix + U</kbd> (which TPM
 5. Optional but recommended: Activate the extra modules, they are enabled by writing 'on' after the option name
 ```bash
 set -g @rose_pine_host 'on' # Enables hostname in the status bar
+set -g @rose_pine_hostname_short 'on' # Makes the hostname shorter by using tmux's '#h' format
 set -g @rose_pine_date_time '' # It accepts the date UNIX command format (man date for info)
 set -g @rose_pine_user 'on' # Turn on the username component in the statusbar
 set -g @rose_pine_directory 'on' # Turn on the current folder component in the status bar

--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -232,6 +232,10 @@ main() {
     hostname_icon="$(get_tmux_option "@rose_pine_hostname_icon" "󰒋")"
     readonly hostname_icon
 
+    local hostname_short
+    hostname_short="$(get_tmux_option "@rose_pine_hostname_short" "")"
+    readonly hostname_short
+
     local date_time_icon
     date_time_icon="$(get_tmux_option "@rose_pine_date_time_icon" "󰃰")"
     readonly date_time_icon
@@ -294,7 +298,14 @@ main() {
     readonly show_user="#[fg=$thm_iris]#(whoami)#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$username_icon"
 
     local show_host
-    readonly show_host="$spacer#[fg=$thm_text]#H#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$hostname_icon"
+    local hostname
+    if [[ "$hostname_short" == "on" ]]; then
+        hostname="#h"
+    else
+        hostname="#H"
+    fi
+    readonly hostname
+    readonly show_host="$spacer#[fg=$thm_text]$hostname#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$hostname_icon"
 
     local show_date_time
     readonly show_date_time=" #[fg=$thm_foam]$date_time#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$date_time_icon "

--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -295,7 +295,7 @@ main() {
     readonly show_session=" #[fg=#{?client_prefix,$thm_love,$thm_text}]$current_session_icon #[fg=$thm_text]#S "
 
     local show_user
-    readonly show_user="#[fg=$thm_iris]#(whoami)#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$username_icon"
+    readonly show_user="#[fg=$thm_iris]#(whoami)#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$username_icon "
 
     local show_host
     local hostname
@@ -305,7 +305,7 @@ main() {
         hostname="#H"
     fi
     readonly hostname
-    readonly show_host="$spacer#[fg=$thm_text]$hostname#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$hostname_icon"
+    readonly show_host="$spacer#[fg=$thm_text]$hostname#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$hostname_icon "
 
     local show_date_time
     readonly show_date_time=" #[fg=$thm_foam]$date_time#[fg=$thm_subtle]$right_separator#[fg=$thm_subtle]$date_time_icon "


### PR DESCRIPTION
This change allows using the shorter tmux hostname format (`#h`) by providing setting `set -g @rose_pine_hostname_short 'on'`.

Closes https://github.com/rose-pine/tmux/issues/35