### PR TITLE
fix: add missing field_separator to fix window padding (fixes #45)

### DIFF
--- a/rose-pine.tmux
+++ b/rose-pine.tmux
@@ -412,7 +412,7 @@ main() {
     if [[ "$disable_active_window_menu" == "on" ]]; then
         left_column=$show_session
     else
-        left_column=$show_session$field_separator$show_window
+        left_column=$show_session$field_separator$show_window$field_separator
     fi
     #
     # Appending / Prepending custom user sections to


### PR DESCRIPTION
This PR adds the missing field_separator to the window status line, which resolves the alignment issues reported in #45. It ensures proper padding between the session name and the window tabs.